### PR TITLE
Add key={canvas.id} to force re-render on canvas navigation

### DIFF
--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/content-types/Atlas/Atlas.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/content-types/Atlas/Atlas.tsx
@@ -67,6 +67,7 @@ const Canvas: React.FC<{
   if (isSmallImage) {
     return (
       <div
+        key={canvas.id}
         style={{
           flex: 1,
           display: 'flex',

--- a/services/madoc-ts/src/frontend/shared/features/SimpleAtlasViewer.tsx
+++ b/services/madoc-ts/src/frontend/shared/features/SimpleAtlasViewer.tsx
@@ -147,7 +147,7 @@ export const SimpleAtlasViewer = React.forwardRef<
         ...style,
       }}
     >
-      <ErrorBoundary resetKeys={[canvas.id]} fallbackRender={() => <GhostCanvas />}>
+      <ErrorBoundary key={canvas.id} resetKeys={[canvas.id]} fallbackRender={() => <GhostCanvas />}>
         <style>
           {`
         .atlas-container {
@@ -161,6 +161,7 @@ export const SimpleAtlasViewer = React.forwardRef<
             {isSmallImage && service ? (
               // Display small images at their original size, centered
               <div
+                key={canvas.id}
                 style={{
                   flex: 1,
                   display: 'flex',


### PR DESCRIPTION
When navigating between canvases in a manifest, the small image display fix wasn't being triggered because React wasn't detecting the need to re-render the component. Adding key={canvas.id} ensures the component properly re-renders when switching between canvases.