### PR TITLE
Fix collection-specific search by adding site_id to JOIN clauses

### DIFF
--- a/services/madoc-ts/src/routes/search/index-canvas.ts
+++ b/services/madoc-ts/src/routes/search/index-canvas.ts
@@ -33,8 +33,8 @@ export const indexCanvas: RouteMiddleware<{ id: string }> = async context => {
   const projectsWithin = manifestsWithin.length
     ? await context.connection.any<{ id: number }>(
         sql`select ip.id from iiif_derived_resource_items cols
-        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id
-        left join iiif_project ip on ip.collection_id = ir.resource_id
+        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id and ir.site_id = cols.site_id
+        left join iiif_project ip on ip.collection_id = ir.resource_id and ip.site_id = cols.site_id
         where item_id = ANY (${sql.array(
           manifestsWithin.map(r => r.resource_id),
           sql`int[]`
@@ -45,7 +45,7 @@ export const indexCanvas: RouteMiddleware<{ id: string }> = async context => {
   const collectionsWithin = manifestsWithin.length
     ? await context.connection.any<{ resource_id: number }>(
         sql`select cols.resource_id from iiif_derived_resource_items cols
-        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id
+        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id and ir.site_id = cols.site_id
         where item_id = ANY (${sql.array(
           manifestsWithin.map(r => r.resource_id),
           sql`int[]`

--- a/services/madoc-ts/src/routes/search/index-manifest.ts
+++ b/services/madoc-ts/src/routes/search/index-manifest.ts
@@ -47,14 +47,14 @@ export const indexManifest: RouteMiddleware<{ id: string }> = async context => {
 
   const collectionsWithin = await context.connection.any<{ resource_id: number }>(
     sql`select cols.resource_id from iiif_derived_resource_items cols
-        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id
+        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id and ir.site_id = cols.site_id
         where item_id = ${manifestId} and cols.site_id = ${Number(siteId)} and ir.flat = false`
   );
 
   const projectsWithin = await context.connection.any<{ id: number }>(
     sql`select ip.id from iiif_derived_resource_items cols
-        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id
-        left join iiif_project ip on ip.collection_id = ir.resource_id
+        left join iiif_derived_resource ir on ir.resource_id = cols.resource_id and ir.site_id = cols.site_id
+        left join iiif_project ip on ip.collection_id = ir.resource_id and ip.site_id = cols.site_id
         where item_id = ${manifestId} and cols.site_id = ${Number(siteId)} and ir.flat = true`
   );
 


### PR DESCRIPTION
The search indexing queries for collections and projects were missing site_id filters in the JOIN conditions with iiif_derived_resource and iiif_project tables. This could cause manifests and canvases to be indexed without proper collection contexts when the same collection exists in multiple sites with different flat values, resulting in empty collection search results.