### PR TITLE
Fix canvas link generation in search results

### DIFF
--- a/services/madoc-ts/src/frontend/site/features/search/SearchResults.tsx
+++ b/services/madoc-ts/src/frontend/site/features/search/SearchResults.tsx
@@ -84,7 +84,11 @@ const SearchItem: React.FC<{ result: SearchResult; size?: 'large' | 'small'; sea
     ? routeContext.collectionId
     : things.find(thing => thing?.type.toLowerCase() === 'collection')?.id;
   const manifestId = things.find(thing => thing?.type.toLowerCase() === 'manifest')?.id;
-  const canvasId = things.find(thing => thing?.type.toLowerCase() === 'canvas')?.id;
+  // If the result is a canvas, get canvas ID from resource_id; otherwise look in contexts
+  const canvasId =
+    result.resource_type === 'Canvas'
+      ? parseUrn(result.resource_id)?.id
+      : things.find(thing => thing?.type.toLowerCase() === 'canvas')?.id;
   const searchText = result.hits && result.hits[0] && result.hits[0].bounding_boxes ? search : undefined;
   const snippet = result.hits && result.hits[0] && result.hits[0].snippet ? result.hits[0].snippet : undefined;
   const isManifest = result.resource_type === 'Manifest';


### PR DESCRIPTION
When a canvas is the search result itself, extract its ID from resource_id instead of contexts. The contexts array contains parent resources (like the manifest), not the result item itself.

This fixes the issue where canvas search results generated incorrect links like /canvases/7749 instead of the correct /manifests/3416/c/7749 format.